### PR TITLE
Make GraphResult static

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/math/GraphUtil.java
+++ b/src/main/java/ac/grim/grimac/utils/math/GraphUtil.java
@@ -72,7 +72,7 @@ public class GraphUtil {
 
     @Getter
     @Setter
-    public class GraphResult {
+    public static class GraphResult {
         private final String graph;
         private final int positives, negatives;
 


### PR DESCRIPTION
Fixes an error I get when compiling on newer jdk versions (11+)

```
C:\fakepath\Grim\src\main\java\ac\grim\grimac\utils\math\GraphUtil.java:44: error: non-static variable this cannot be referenced from a static context
        return new GraphResult(graph.toString(), positives, negatives);
               ^
C:\fakepath\Grim\src\main\java\ac\grim\grimac\utils\math\GraphUtil.java:70: error: non-static variable this cannot be referenced from a static context
        return new GraphResult(positives, negatives);
               ^
```