### PR TITLE
Fix playerWorld desync

### DIFF
--- a/src/main/java/ac/grim/grimac/events/bukkit/TeleportEvent.java
+++ b/src/main/java/ac/grim/grimac/events/bukkit/TeleportEvent.java
@@ -10,7 +10,7 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
 public class TeleportEvent implements Listener {
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerTeleportEvent(PlayerTeleportEvent event) {
         if (event.getPlayer().hasMetadata("NPC")) return;
         // How can getTo be null?


### PR DESCRIPTION
Same type of fix as last one. A plugin cancelling a teleport between worlds would desync the playerWorld variable. I believe it's also needed for the events in PistonEvent listener but replicating that to see if it does is a bit more difficult. 