### PR TITLE
Set maxAdvantage variable to MAX_VALUE

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/prediction/OffsetHandler.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/prediction/OffsetHandler.java
@@ -80,7 +80,7 @@ public class OffsetHandler extends PostPredictionCheck {
         maxAdvantage = getConfig().getDoubleElse("Simulation.max-advantage", 1);
         maxCeiling = getConfig().getDoubleElse("Simulation.max-ceiling", 4);
 
-        if (maxAdvantage == -1) setbackVL = Double.MAX_VALUE;
+        if (maxAdvantage == -1) maxAdvantage = Double.MAX_VALUE;
         if (immediateSetbackThreshold == -1) immediateSetbackThreshold = Double.MAX_VALUE;
     }
 


### PR DESCRIPTION
setbackVL isn't used in this class and setbacks will still happen if advantageGained >= maxAdvantage even if setting maxAdvantage to -1 (as implied here: https://github.com/MWHunter/Grim/blob/2.0/src/main/resources/config/en.yml#L31)

https://github.com/MWHunter/Grim/blob/2.0/src/main/java/ac/grim/grimac/checks/impl/prediction/OffsetHandler.java#L39-L44