### PR TITLE
GrimAC -> JavaPlugin

### DIFF
--- a/src/main/java/ac/grim/grimac/GrimAPI.java
+++ b/src/main/java/ac/grim/grimac/GrimAPI.java
@@ -3,6 +3,7 @@ package ac.grim.grimac;
 import ac.grim.grimac.manager.*;
 import ac.grim.grimac.utils.anticheat.PlayerDataManager;
 import lombok.Getter;
+import org.bukkit.plugin.java.JavaPlugin;
 
 @Getter
 public enum GrimAPI {
@@ -15,20 +16,20 @@ public enum GrimAPI {
     private final DiscordManager discordManager = new DiscordManager();
 
     private ConfigManager configManager;
-    private GrimAC plugin;
+    private JavaPlugin plugin;
 
-    public void load(final GrimAC plugin) {
+    public void load(final JavaPlugin plugin) {
         this.plugin = plugin;
         this.configManager = new ConfigManager();
         initManager.load();
     }
 
-    public void start(final GrimAC plugin) {
+    public void start(final JavaPlugin plugin) {
         this.plugin = plugin;
         initManager.start();
     }
 
-    public void stop(final GrimAC plugin) {
+    public void stop(final JavaPlugin plugin) {
         this.plugin = plugin;
         initManager.stop();
     }


### PR DESCRIPTION
This isn't *strictly* needed for the normal usage of the plugin, but having the plugin property being an instance of GrimAC prevents other plugins from shading it, and there is no usage of plugin that specifically needs it to be the GrimAC class.
![image](https://user-images.githubusercontent.com/8620569/163489434-0274bb9a-ac1f-4efc-b88c-bbc3a41a8b49.png)
