### PR TITLE
Add support for Floodgate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
     maven { url = "https://repo.aikar.co/content/groups/aikar/" } // ACF
     maven { url = "https://nexus.scarsz.me/content/groups/public" } // Configuralize
     maven { url = "https://clojars.org/repo" } // MultiPaper MultiLib
+    maven { url = "https://repo.opencollab.dev/maven-snapshots/" } // Floodgate
     mavenCentral() // FastUtil, Discord-Webhooks, Lombok
 }
 
@@ -37,6 +38,7 @@ dependencies {
     implementation 'github.scarsz:configuralize:1.4.0'
     implementation 'com.github.puregero:multilib:1.1.3'
 
+    compileOnly 'org.geysermc.floodgate:api:2.0-SNAPSHOT'
     compileOnly 'org.spigotmc:spigot-api:1.18-R0.1-SNAPSHOT'
     compileOnly 'com.viaversion:viaversion-api:4.1.1'
     compileOnly 'org.projectlombok:lombok:1.18.22'

--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -15,6 +15,7 @@ import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.*;
 import ac.grim.grimac.utils.enums.FluidTag;
 import ac.grim.grimac.utils.enums.Pose;
+import ac.grim.grimac.utils.floodgate.FloodgateUtil;
 import ac.grim.grimac.utils.latency.*;
 import ac.grim.grimac.utils.math.TrigHandler;
 import ac.grim.grimac.utils.nmsutil.GetBoundingBox;
@@ -408,7 +409,8 @@ public class GrimPlayer {
             this.playerUUID = user.getUUID();
             if (this.playerUUID != null) {
                 // Geyser players don't have Java movement
-                if (GeyserUtil.isGeyserPlayer(playerUUID)) {
+                // Floodgate is the authentication system for Geyser on servers that use Geyser as a proxy instead of installing it as a plugin directly on the server
+                if (GeyserUtil.isGeyserPlayer(playerUUID) || FloodgateUtil.isFloodgatePlayer(playerUUID)) {
                     GrimAPI.INSTANCE.getPlayerDataManager().remove(user);
                     return true;
                 }

--- a/src/main/java/ac/grim/grimac/utils/floodgate/FloodgateUtil.java
+++ b/src/main/java/ac/grim/grimac/utils/floodgate/FloodgateUtil.java
@@ -1,0 +1,30 @@
+package ac.grim.grimac.utils.floodgate;
+
+import org.geysermc.floodgate.api.FloodgateApi;
+
+import java.util.UUID;
+
+public class FloodgateUtil {
+
+    private static boolean CHECKED_FOR_FLOODGATE;
+    private static boolean FLOODGATE_PRESENT;
+
+    public static boolean isFloodgatePlayer(UUID uuid) {
+        if (!CHECKED_FOR_FLOODGATE) {
+            try {
+                Class.forName("org.geysermc.floodgate.api.FloodgateApi");
+                FLOODGATE_PRESENT = true;
+            } catch (ClassNotFoundException e) {
+                FLOODGATE_PRESENT = false;
+            }
+            CHECKED_FOR_FLOODGATE = true;
+        }
+
+        if (FLOODGATE_PRESENT) {
+            return FloodgateApi.getInstance().isFloodgatePlayer(uuid);
+        } else {
+            return false;
+        }
+    }
+
+}


### PR DESCRIPTION
Floodgate is the authentication system used for Geyser on servers that run Geyser as a proxy instead of installing it as a plugin directly on the server. This means GeyserUtil is unable to check if a player is a Geyser player, and thus Floodgate needs to be checked instead.